### PR TITLE
Handle missing credentials in login

### DIFF
--- a/app.py
+++ b/app.py
@@ -68,6 +68,8 @@ def create_user_table():
         conn.commit()
 
 def hash_password(password):
+    if password is None:
+        raise ValueError("Password cannot be None")
     return hashlib.sha256(password.encode()).hexdigest()
 
 def allowed_file(filename):
@@ -92,9 +94,14 @@ def compress_image(image_path, quality=85):
 
 @app.route('/login', methods=['POST'])
 def login():
-    data = request.json
+    data = request.json or {}
     username = data.get('username')
     password = data.get('password')
+
+    # Ensure required credentials are provided
+    if not username or not password:
+        return jsonify({'success': False, 'message': 'Username and password are required'}), 400
+
     password_hash = hash_password(password)
 
     with sqlite3.connect(DB_PATH) as conn:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -108,6 +108,21 @@ class IBBBackendTestCase(unittest.TestCase):
         
         data = json.loads(response.data)
         self.assertFalse(data['success'])
+
+    def test_login_missing_password(self):
+        """Login should fail gracefully when password is missing"""
+        login_data = {
+            'username': 'user_without_password'
+        }
+
+        response = self.app.post('/login',
+                                data=json.dumps(login_data),
+                                content_type='application/json')
+
+        self.assertEqual(response.status_code, 400)
+        data = json.loads(response.data)
+        self.assertFalse(data['success'])
+        self.assertIn('required', data['message'])
     
     def test_save_form_validation(self):
         """Test form data validation"""


### PR DESCRIPTION
## Summary
- guard against absent username/password in login request
- raise clearer error when hashing a missing password
- test login behavior when password field is missing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bf7fd91c48328ac54a42fe979bb8c